### PR TITLE
Add heading for `exec`

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,10 +94,12 @@ func getCmdArgs(o, c []string) (string, []string) {
 	for i := len(o) - 1; i >= 0; i-- {
 		arg := o[i]
 		if arg == "--" {
+
 			if i == 0 {
 				return defaultExecHeading, o[i+1:]
 			}
-			return strings.Join(c[0:i-2], " "), o[i+1:]
+			r := o[i+1:]
+			return strings.Join(c[0:len(r)], " "), r
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,9 @@ var opts *render.Options
 const maxBufferSize = 32 * 1024
 
 func init() {
-	opts = &render.Options{}
+	opts = &render.Options{
+		HeadingSuffix: " ",
+	}
 
 	rootCmd.PersistentFlags().StringVarP(&opts.Color, "color", "c", "neutral", "line color")
 	rootCmd.PersistentFlags().StringVarP(&opts.Level, "level", "l", "trace", "log level")
@@ -135,9 +137,6 @@ func handleInput(level string, args []string) {
 	i := 0
 	for scanner.Scan() {
 		body := scanner.Text()
-		if i == 0 {
-			body = indentOutput(body, opts.ShortHeading)
-		}
 		i++
 
 		m := &logging.Message{

--- a/pkg/logging/message.go
+++ b/pkg/logging/message.go
@@ -69,8 +69,9 @@ type LineParser interface {
 }
 
 //TODO: Make configurable
-var timestampKeys = []string{"ts", "time", "timestamp", "date"}
+var timestampKeys = []string{"ts", "time", "timestamp", "date", "@timestamp"}
 var messageKeys = []string{"message", "msg"}
+var levelKeys = []string{"level", "log.level"}
 
 //JSONLineParser implements LineParser
 type JSONLineParser struct {
@@ -98,8 +99,10 @@ func (p JSONLineParser) Parse(line []byte) (*Message, error) {
 		}
 	}
 
-	if !parseLevelString(m, data, "level") {
-		parseLevelInt(m, data, "level")
+	for _, key := range levelKeys {
+		if !parseLevelString(m, data, key) {
+			parseLevelInt(m, data, key)
+		}
 	}
 
 	for _, key := range messageKeys {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -21,6 +21,7 @@ type Options struct {
 	Heading         string
 	ShortHeading    bool
 	HeadingPrefix   string
+	HeadingSuffix   string
 	NoNewline       bool
 	NoTimestamp     bool
 	Modifiers       *[]string
@@ -34,8 +35,15 @@ var IndentationChar string = " └─"
 var TimestampFormat = "01-02-2006 15:04:05.000000"
 
 //WithIndent sets heading with indent option
-func (o *Options) WithIndent() {
+func (o *Options) WithIndent() *Options {
 	o.HeadingPrefix = IndentationChar
+	return o
+}
+
+//WithHeadingSuffix sets heading suffix
+func (o *Options) WithHeadingSuffix(s string) *Options {
+	o.HeadingSuffix = s
+	return o
 }
 
 //HasIndent returns true if heading has indent
@@ -62,12 +70,14 @@ func styleHeading(heading string, opts *Options) string {
 
 	if style, ok := headingStyle[opts.Level]; ok {
 		heading = style.Paint(heading)
-		heading += " "
 	}
 
-	if opts.HeadingPrefix != "" {
+	heading += opts.HeadingSuffix
+
+	if opts.HasIndent() {
 		heading = opts.HeadingPrefix + heading
 	}
+
 	return heading
 }
 
@@ -94,7 +104,6 @@ func Stylize(msg *logging.Message, opts *Options) (string, string) {
 		if opts.HasIndent() {
 			ts = strings.Repeat(" ", utf8.RuneCountInString(opts.TimestampFormat))
 		}
-
 		heading = fmt.Sprintf("%s %s", ts, heading)
 	}
 


### PR DESCRIPTION
This PR closes #15 and adds a heading/label argument(s) to the command:

```
lgr cmd -S=true --no-timestamp=true 'listing files'  -- cat main.go
[✔] success listing files: cat main.go
 └─[I][01] package main
 └─[I][02] 
 └─[I][03] import (
 └─[I][04]      "github.com/goliatone/lgr/cmd"
 └─[I][05] )
 └─[I][06] 
 └─[I][07] //main entry point of our CLI
 └─[I][08] //commands.
 └─[I][09] func main() {
 └─[I][10]      cmd.Execute()
 └─[I][11] }
```